### PR TITLE
Mac fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,4 +26,4 @@ list(FILTER AECM_SRC EXCLUDE REGEX ".*aecm_core_neon.cc$")
 list(FILTER AECM_SRC EXCLUDE REGEX ".*aecm_core_mips.cc$")
 set(AECM_COMPILE_CODE ${AECM_SRC})
 
-add_executable(aecm main.cc ${AECM_COMPILE_CODE})
+add_executable(aecm_run main.cc ${AECM_COMPILE_CODE})

--- a/main.cc
+++ b/main.cc
@@ -187,7 +187,7 @@ int main(int argc, char *argv[]) {
     char ext[256];
     char out_file[1024];
     splitpath(near_file, drive, dir, fname, ext);
-    sprintf(out_file, "%s%s%s_out%s", drive, dir, fname, ext);
+    snprintf(out_file, sizeof(out_file), "%s%s%s_out%s", drive, dir, fname, ext);
     AECM(near_file, far_file, out_file);
     printf("press any key to exit. \n");
     getchar();

--- a/timing.h
+++ b/timing.h
@@ -21,14 +21,7 @@ static
 uint64_t nanotimer() {
     static int ever = 0;
 #if defined(__APPLE__)
-    static mach_timebase_info_data_t frequency;
-    if (!ever) {
-        if (mach_timebase_info(&frequency) != KERN_SUCCESS) {
-            return 0;
-        }
-        ever = 1;
-    }
-    return;
+    return clock_gettime_nsec_np(CLOCK_MONOTONIC);
 #elif defined(_WIN32)
     static LARGE_INTEGER frequency;
     if (!ever) {


### PR DESCRIPTION
Fixes to get the code running on a modern MacOS system (MacOS Ventura, M1 Pro). Changes were:

* CMakeLists.txt -> changed the name of the executable from `aecm` to `aecm_run` as it clashes with the name of the `aecm` directory
* Changed an `sprintf()` call to `snprintf()` because `sprintf` throws a warning converted to error in clang
* Implemented `nanotimer()` for mac 